### PR TITLE
qca-nss-dp: support linux-6.9

### DIFF
--- a/package/qca-nss-dp/0011-nss-dp-Fix-build-falures-due-to-Wmissing-prototypes.patch
+++ b/package/qca-nss-dp/0011-nss-dp-Fix-build-falures-due-to-Wmissing-prototypes.patch
@@ -1,0 +1,113 @@
+From 34b48f95a3e5bb9f1a8afc8f40da3039371bdcce Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Sat, 23 Mar 2024 06:20:01 -0500
+Subject: [PATCH 11/13] nss-dp: Fix build falures due to -Wmissing-prototypes
+
+Some functions are only used iwthin the same file, and sould thus be
+declared static. For others, the correct header wasn't included. These
+error are exposed by the "-Wmissing-prototypes" compiler flag.
+
+Mark static functions as static, and include the correct headers for
+global functions.
+
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+---
+ hal/dp_ops/edma_dp/edma_v1/edma_cfg.c |  2 +-
+ hal/gmac_ops/qcom/qcom_if.c           |  4 ++--
+ nss_dp_main.c                         | 10 +++++++---
+ 3 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/hal/dp_ops/edma_dp/edma_v1/edma_cfg.c b/hal/dp_ops/edma_dp/edma_v1/edma_cfg.c
+index f2542e8..fba67c4 100644
+--- a/hal/dp_ops/edma_dp/edma_v1/edma_cfg.c
++++ b/hal/dp_ops/edma_dp/edma_v1/edma_cfg.c
+@@ -714,7 +714,7 @@ static void edma_configure_rings(struct edma_hw *ehw)
+  * edma_hw_reset()
+  *	Reset EDMA Hardware during initialization
+  */
+-int edma_hw_reset(struct edma_hw *ehw)
++static int edma_hw_reset(struct edma_hw *ehw)
+ {
+ 	struct reset_control *rst;
+ 	struct platform_device *pdev = ehw->pdev;
+diff --git a/hal/gmac_ops/qcom/qcom_if.c b/hal/gmac_ops/qcom/qcom_if.c
+index 90afca1..40d4388 100644
+--- a/hal/gmac_ops/qcom/qcom_if.c
++++ b/hal/gmac_ops/qcom/qcom_if.c
+@@ -238,7 +238,7 @@ static int32_t qcom_get_netdev_stats(struct nss_gmac_hal_dev *nghd,
+  * qcom_get_strset_count()
+  *	Get string set count for ethtool operations
+  */
+-int32_t qcom_get_strset_count(struct nss_gmac_hal_dev *nghd, int32_t sset)
++static int32_t qcom_get_strset_count(struct nss_gmac_hal_dev *nghd, int32_t sset)
+ {
+ 	struct net_device *netdev = nghd->netdev;
+ 
+@@ -257,7 +257,7 @@ int32_t qcom_get_strset_count(struct nss_gmac_hal_dev *nghd, int32_t sset)
+  * qcom_get_strings()
+  *	Get strings
+  */
+-int32_t qcom_get_strings(struct nss_gmac_hal_dev *nghd, int32_t sset,
++static int32_t qcom_get_strings(struct nss_gmac_hal_dev *nghd, int32_t sset,
+ 						uint8_t *data)
+ {
+ 	struct net_device *netdev = nghd->netdev;
+diff --git a/nss_dp_main.c b/nss_dp_main.c
+index 006d519..615b0fe 100644
+--- a/nss_dp_main.c
++++ b/nss_dp_main.c
+@@ -16,6 +16,8 @@
+  * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#include "nss_dp_dev.h"
++
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/version.h>
+@@ -706,7 +708,7 @@ bool nss_dp_is_phy_dev(struct net_device *dev)
+ /*
+  * nss_dp_adjust_link()
+  */
+-void nss_dp_adjust_link(struct net_device *netdev)
++static void nss_dp_adjust_link(struct net_device *netdev)
+ {
+ 	struct nss_dp_dev *dp_priv = netdev_priv(netdev);
+ 	int current_state = dp_priv->link_state;
+@@ -992,6 +994,7 @@ int32_t nss_dp_get_port_num(struct net_device *netdev)
+ }
+ EXPORT_SYMBOL(nss_dp_get_port_num);
+ 
++#ifdef NSS_DP_PPEDS_SUPPORT
+ /*
+  * nss_dp_ppeds_get_ops()
+  *	API to get PPE-DS operations
+@@ -1001,6 +1004,7 @@ struct nss_dp_ppeds_ops *nss_dp_ppeds_get_ops(void)
+ 	return nss_dp_ppeds_ops_get();
+ }
+ EXPORT_SYMBOL(nss_dp_ppeds_get_ops);
++#endif
+ 
+ /*
+  * nss_dp_nsm_sawf_sc_stats_read()
+@@ -1015,7 +1019,7 @@ EXPORT_SYMBOL(nss_dp_nsm_sawf_sc_stats_read);
+ /*
+  * nss_dp_init()
+  */
+-int __init nss_dp_init(void)
++static int __init nss_dp_init(void)
+ {
+ 	int ret;
+ 
+@@ -1076,7 +1080,7 @@ int __init nss_dp_init(void)
+ /*
+  * nss_dp_exit()
+  */
+-void __exit nss_dp_exit(void)
++static void __exit nss_dp_exit(void)
+ {
+ 	/*
+ 	 * TODO Move this to soc_ops
+-- 
+2.40.1
+

--- a/package/qca-nss-dp/0012-nss-dp-nss_dp_dev.h-Remove-unused-linux-switch.h-inc.patch
+++ b/package/qca-nss-dp/0012-nss-dp-nss_dp_dev.h-Remove-unused-linux-switch.h-inc.patch
@@ -1,0 +1,32 @@
+From 0ead1c5f2c144f557050e4ba1a4e80e6ac3c4cf5 Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Sat, 23 Mar 2024 06:30:48 -0500
+Subject: [PATCH 12/13] nss-dp: nss_dp_dev.h: Remove unused <linux/switch.h>
+ include
+
+The "linux/switch.h" header is specific to OpenWRT, and not part of
+the upstream kernel. Thus, when building for a generic kernel, this
+will cause a build failure.
+
+This header isn't used, so just don't include it.
+
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+---
+ include/nss_dp_dev.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/nss_dp_dev.h b/include/nss_dp_dev.h
+index 5a8c0f7..c1edb49 100644
+--- a/include/nss_dp_dev.h
++++ b/include/nss_dp_dev.h
+@@ -22,7 +22,6 @@
+ #include <linux/etherdevice.h>
+ #include <linux/netdevice.h>
+ #include <linux/platform_device.h>
+-#include <linux/switch.h>
+ #include <linux/version.h>
+ #include <linux/ethtool.h>
+ 
+-- 
+2.40.1
+

--- a/package/qca-nss-dp/0013-nss-dp-support-linux-6.9.patch
+++ b/package/qca-nss-dp/0013-nss-dp-support-linux-6.9.patch
@@ -1,0 +1,163 @@
+From cb7837d6b93b005740f5219b973fa534bd915bec Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Fri, 5 Apr 2024 00:10:17 -0500
+Subject: [PATCH 13/13] nss-dp: support linux 6.9
+
+In linux v6.9, struct rps_sock_flow_table has been moved to its own
+header. struct ethtool_eee has been replaced with struct_keee.
+
+The bitfields of struct_keee should not be accessed directly. The
+ethtool_convert_link_mode_to_legacy_u32() and
+ethtool_convert_legacy_u32_to_link_mode() helpers should be used
+instead.
+
+Implement these changes on an #ifdef basis, in order to maintain
+compatibilty with older kernels.
+
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+---
+ nss_dp_ethtools.c | 47 +++++++++++++++++++++++++++++++++++++++--------
+ nss_dp_main.c     | 13 ++++++++++++-
+ 2 files changed, 51 insertions(+), 9 deletions(-)
+
+diff --git a/nss_dp_ethtools.c b/nss_dp_ethtools.c
+index a0ab0d3..81bd845 100644
+--- a/nss_dp_ethtools.c
++++ b/nss_dp_ethtools.c
+@@ -248,11 +248,15 @@ static inline void nss_dp_fal_to_ethtool_linkmode_xlate(uint32_t *xlate_to, uint
+  * nss_dp_get_eee()
+  *	Get EEE settings.
+  */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
++static int32_t nss_dp_get_eee(struct net_device *netdev, struct ethtool_keee *eee)
++#else
+ static int32_t nss_dp_get_eee(struct net_device *netdev, struct ethtool_eee *eee)
++#endif
+ {
+ 	struct nss_dp_dev *dp_priv = (struct nss_dp_dev *)netdev_priv(netdev);
+ 	fal_port_eee_cfg_t port_eee_cfg;
+-	uint32_t port_id;
++	uint32_t port_id, supported, advertised, lp_advertised;
+ 	sw_error_t ret;
+ 
+ 	memset(&port_eee_cfg, 0, sizeof(fal_port_eee_cfg_t));
+@@ -266,9 +270,20 @@ static int32_t nss_dp_get_eee(struct net_device *netdev, struct ethtool_eee *eee
+ 	/*
+ 	 * Translate the FAL linkmode types to ethtool linkmode types.
+ 	 */
+-	nss_dp_fal_to_ethtool_linkmode_xlate(&eee->supported, &port_eee_cfg.capability);
+-	nss_dp_fal_to_ethtool_linkmode_xlate(&eee->advertised, &port_eee_cfg.advertisement);
+-	nss_dp_fal_to_ethtool_linkmode_xlate(&eee->lp_advertised, &port_eee_cfg.link_partner_advertisement);
++	nss_dp_fal_to_ethtool_linkmode_xlate(&supported, &port_eee_cfg.capability);
++	nss_dp_fal_to_ethtool_linkmode_xlate(&advertised, &port_eee_cfg.advertisement);
++	nss_dp_fal_to_ethtool_linkmode_xlate(&lp_advertised, &port_eee_cfg.link_partner_advertisement);
++
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
++	ethtool_convert_legacy_u32_to_link_mode(eee->supported, supported);
++	ethtool_convert_legacy_u32_to_link_mode(eee->advertised, advertised);
++	ethtool_convert_legacy_u32_to_link_mode(eee->lp_advertised, lp_advertised);
++#else
++	eee->supported = supported;
++	eee->advertised = advertised;
++	eee->lp_advertised = lp_advertised;
++#endif
++
+ 	eee->eee_enabled = port_eee_cfg.enable;
+ 	eee->eee_active = port_eee_cfg.eee_status;
+ 	eee->tx_lpi_enabled = port_eee_cfg.lpi_tx_enable;
+@@ -281,11 +296,15 @@ static int32_t nss_dp_get_eee(struct net_device *netdev, struct ethtool_eee *eee
+  * nss_dp_set_eee()
+  *	Set EEE settings.
+  */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
++static int32_t nss_dp_set_eee(struct net_device *netdev, struct ethtool_keee *eee)
++#else
+ static int32_t nss_dp_set_eee(struct net_device *netdev, struct ethtool_eee *eee)
++#endif
+ {
+ 	struct nss_dp_dev *dp_priv = (struct nss_dp_dev *)netdev_priv(netdev);
+ 	fal_port_eee_cfg_t port_eee_cfg, port_eee_cur_cfg;
+-	uint32_t port_id, pos;
++	uint32_t port_id, pos, advertised;
+ 	sw_error_t ret;
+ 
+ 	memset(&port_eee_cfg, 0, sizeof(fal_port_eee_cfg_t));
+@@ -303,11 +322,17 @@ static int32_t nss_dp_set_eee(struct net_device *netdev, struct ethtool_eee *eee
+ 
+ 	port_eee_cfg.enable = eee->eee_enabled;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
++	ethtool_convert_link_mode_to_legacy_u32(&advertised, eee->advertised);
++#else
++	advertised = eee->advertised;
++#endif
++
+ 	/*
+ 	 * Translate the ethtool speed types to FAL speed types.
+ 	 */
+-	while (eee->advertised) {
+-		pos = ffs(eee->advertised);
++	while (advertised) {
++		pos = ffs(advertised);
+ 		switch (1 << (pos - 1)) {
+ 		case ADVERTISED_10baseT_Full:
+ 			if (port_eee_cur_cfg.capability & FAL_PHY_EEE_10BASE_T) {
+@@ -359,9 +384,15 @@ static int32_t nss_dp_set_eee(struct net_device *netdev, struct ethtool_eee *eee
+ 			return -EIO;
+ 		}
+ 
+-		eee->advertised &= (~(1 << (pos - 1)));
++		advertised &= (~(1 << (pos - 1)));
+ 	}
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
++	ethtool_convert_legacy_u32_to_link_mode(eee->advertised, advertised);
++#else
++	eee->advertised = advertised;
++#endif
++
+ 	port_eee_cfg.lpi_tx_enable = eee->tx_lpi_enabled;
+ 	port_eee_cfg.lpi_sleep_timer = eee->tx_lpi_timer;
+ 	ret = fal_port_interface_eee_cfg_set(NSS_DP_ACL_DEV_ID, port_id, &port_eee_cfg);
+diff --git a/nss_dp_main.c b/nss_dp_main.c
+index 615b0fe..18071ba 100644
+--- a/nss_dp_main.c
++++ b/nss_dp_main.c
+@@ -39,6 +39,9 @@
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
+ #include <net/netdev_rx_queue.h>
+ #endif
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++#include <net/rps.h>
++#endif
+ 
+ #include "nss_dp_hal.h"
+ 
+@@ -483,15 +486,23 @@ static int nss_dp_rx_flow_steer(struct net_device *netdev, const struct sk_buff
+ 	rxflow = &flow_table->flows[hash & flow_table->mask];
+ 	rxcpu = (uint32_t)rxflow->cpu;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++	sock_flow_table = rcu_dereference(net_hotdata.rps_sock_flow_table);
++#else
+ 	sock_flow_table = rcu_dereference(rps_sock_flow_table);
++#endif
+ 	if (!sock_flow_table) {
+ 		netdev_dbg(netdev, "Global RPS flow table not found\n");
+ 		return -EINVAL;
+ 	}
+ 
+ 	rfscpu = sock_flow_table->ents[hash & sock_flow_table->mask];
+-	rfscpu &= rps_cpu_mask;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
++	rfscpu &= net_hotdata.rps_cpu_mask;
++#else
++	rfscpu &= rps_cpu_mask;
++#endif
+ 	if (rxcpu == rfscpu)
+ 		return 0;
+ 
+-- 
+2.40.1
+


### PR DESCRIPTION
NSS_DP continues to fail in unexpected, great and wonderful ways. The first half of the patch train fixes some irritating compiler warnings. After all, qca-nss-dp tries to enable "-Werror" in its makefile. In the second half of the patch train add API adjustments to make nss-dp work on linux-6.9.